### PR TITLE
Allows choosing a different encription key

### DIFF
--- a/cfn.yml
+++ b/cfn.yml
@@ -42,6 +42,7 @@ Resources:
                       Name: paramName,
                       Type: props.Type,
                       Value: props.Value,
+                      KeyId: props.KeyId,
                       Overwrite: false
                   };
 
@@ -54,6 +55,7 @@ Resources:
                       Name: paramName,
                       Type: props.Type,
                       Value: props.Value,
+                      KeyId: props.KeyId,
                       Overwrite: true
                   };
 
@@ -93,6 +95,7 @@ Resources:
                 Action:
                   - ssm:PutParameter
                   - ssm:DeleteParameter
+                  - kms:Encrypt
                 Resource: "*"
 Outputs:
   Lambda:


### PR DESCRIPTION
I had to add an extra permission to the lambda role so it can encrypt secrets with a different key other than the default one. I don't know what others think about this.