### PR TITLE
Add IAM Role Arn as an output

### DIFF
--- a/cfn.yml
+++ b/cfn.yml
@@ -103,3 +103,8 @@ Outputs:
     Value: !GetAtt Lambda.Arn
     Export:
       Name: CfnParamStore
+  HelperRole:
+    Description: IAM Role
+    Value: !GetAtt Role.Arn
+    Export:
+      Name: SSMHelperRole


### PR DESCRIPTION
In order to [specify a KMS key to encrypt SSM parameters](https://github.com/glassechidna/ssmcfn/commit/731729ffe9d84d43b96daa33da40aa8c5cdaaa09), the IAM role needs to be granted permissions in the key's policy; if the IAM Role's Arn is exposed as an output this can be done using the ImportValue intrinsic function.